### PR TITLE
Ensure we use absolute path to register service worker

### DIFF
--- a/lib/register-sw.html
+++ b/lib/register-sw.html
@@ -1,7 +1,7 @@
 <script data-sw-registration>
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker
-      .register('./ember-minimal-service-worker/sw.js')
+      .register('/ember-minimal-service-worker/sw.js')
       .catch((error) => {
         console.error('Could not setup service worker: ' + error);
       });


### PR DESCRIPTION
To ensure the service worker is always properly registered, even when we load the app on the non-root page.